### PR TITLE
Don't convert strip option to string.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -27,8 +27,7 @@ const cli = meow(`
 	string: [
 		'filename',
 		'out',
-		'proxy',
-		'strip'
+		'proxy'
 	],
 	alias: {
 		e: 'extract',


### PR DESCRIPTION
Currently the strip option is converted to a string, which causes this error on decompress:
```
Error: The Second argument of strip-dirs must be a natural number or 0, but received '1'.
    at stripDirs (.../node_modules/download-cli/node_modules/strip-dirs/index.js:27:11)
    at files.map.x (.../node_modules/download-cli/node_modules/decompress/index.js:26:14)
    at Array.map (native)
    at runPlugins.then.files (.../node_modules/download-cli/node_modules/decompress/index.js:25:5)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:169:7)
```

This just removes the explicit option sent to meow so minimist parses it as a number.