### PR TITLE
Adding an option to not pipe the output to stdout.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -20,8 +20,10 @@ const cli = meow(`
 	  -s, --strip <number>  Strip leading paths from file names on extraction
 	  --filename <string>   Name of the saved file
 	  --proxy <string>      Proxy endpoint
+	  --no-pipe             Don't pipe to stdout
 `, {
 	boolean: [
+		'nopipe',
 		'extract'
 	],
 	string: [
@@ -41,4 +43,8 @@ if (cli.input.length === 0) {
 	process.exit(1);
 }
 
-download(cli.input[0], cli.flags.out, cli.flags).pipe(process.stdout);
+let stream = download(cli.input[0], cli.flags.out, cli.flags)
+
+if(!cli.flags.nopipe) {
+	stream.pipe(process.stdout);
+}


### PR DESCRIPTION
I'm not sure if this is just me being stupid or if it really isn't working, but I simply can't get the `--extract` option to work with the way the CLI currently works. This is what I'm doing:

```
download -e -o dist -s 1 --filename test.zip https://dl.nwjs.io/v0.23.4/nwjs-v0.23.4-win-x64.zip > test.zip
```

I've tried a lot of variations of that also, with no success. The file downloads correctly but nothing is extracted to `out`. However, removing the pipe to `stdout` worked for me, so I added a command line option to disable the pipe to `stdout`. I'm sure there's a more elegant fix for this, but for now this will do for me, and maybe can be worked on to something.

Thanks for your work!