### PR TITLE
Upgrade dependencies and switch to modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "email": "kevinmartensson@gmail.com",
     "url": "github.com/kevva"
   },
-	"type": "module",
+  "type": "module",
   "bin": {
     "download": "cli.js"
   },

--- a/package.json
+++ b/package.json
@@ -9,11 +9,12 @@
     "email": "kevinmartensson@gmail.com",
     "url": "github.com/kevva"
   },
+	"type": "module",
   "bin": {
     "download": "cli.js"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=16.10"
   },
   "scripts": {
     "test": "xo && ava"
@@ -31,14 +32,14 @@
     "url"
   ],
   "dependencies": {
-    "download": "^6.2.1",
-    "meow": "^3.3.0"
+    "download": "^8.0.0",
+    "meow": "^12.1.1"
   },
   "devDependencies": {
     "ava": "*",
-    "execa": "^0.7.0",
-    "path-exists": "^3.0.0",
-    "rimraf": "^2.6.1",
+    "execa": "^8.0.1",
+    "path-exists": "^5.0.0",
+    "rimraf": "^5.0.1",
     "xo": "*"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,11 +1,14 @@
-import path from 'path';
-import execa from 'execa';
-import pathExists from 'path-exists';
-import rimraf from 'rimraf';
+import path from 'node:path';
+import * as url from 'node:url';
+import {execa} from 'execa';
+import {pathExistsSync} from 'path-exists';
+import {rimraf} from 'rimraf';
 import test from 'ava';
 
-test(async t => {
-	await execa.stdout(path.join(__dirname, 'cli.js'), ['--out', __dirname, 'https://github.com/kevva/download-cli/archive/master.zip']);
-	t.true(pathExists.sync(path.join(__dirname, 'download-cli-master.zip')));
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
+
+test('Download file from GitHub', async t => {
+	await execa(path.join(__dirname, 'cli.js'), ['--out', __dirname, 'https://github.com/kevva/download-cli/archive/master.zip']);
+	t.true(pathExistsSync(path.join(__dirname, 'download-cli-master.zip')));
 	rimraf.sync(path.join(__dirname, 'download-cli-master.zip'));
 });


### PR DESCRIPTION
The main purpose of the change is to upgrade the dependencies, however whilst doing so I found that I needed to switch to a module to support the new version of `ava` and to do some other fixes for the changed default rules in `xo`/`ESLint`.